### PR TITLE
Fix license in `composer.json`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
         "notifications"
     ],
     "type": "flarum-extension",
-    "license": "mit",
+    "license": "MIT",
     "authors": [
         {
             "name": "Timotheus Pokorra",


### PR DESCRIPTION
Some tools does not recognize lowercased `mit` as MIT License. For example https://shields.io uses "unknown" color in such case:

![](https://img.shields.io/packagist/l/tpokorra/flarum-ext-post-notification)

![08ecaa26](https://user-images.githubusercontent.com/5972388/125205330-f4c2d580-e281-11eb-855d-56a2141bb3c8.png)
